### PR TITLE
Fix YAML to use var value instead of var name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Ensure language packages are installed
   apt: pkg={{ item }} state=installed
-  with_items: locale_language_packs
+  with_items: "{{ locale_language_packs }}"
   sudo: yes
   register: locale_languages
 
@@ -50,5 +50,5 @@
 
 - name: Ensure locales is generated
   locale_gen: name={{ item.locale }} state={{ item.state }}
-  with_items: locale_locales
+  with_items: "{{ locale_locales }}"
   sudo: yes


### PR DESCRIPTION
Before this change, I got errors on these tasks because it was using the
variable name instead of the variable value. For example, on the "Ensure
language packages are installed" task, I got an error that apt
could not find the `locale_language_packs` package. But it should have
been looking for the _contents_ of the variable, e.g. `language-pack-en`
and `language-pack-en-base`.